### PR TITLE
1. 修复“隐藏广告”失效的问题

### DIFF
--- a/src/modules/rules/video/groups/right.scss
+++ b/src/modules/rules/video/groups/right.scss
@@ -42,6 +42,9 @@ html[video-page-hide-right-container-ad] {
         .ad-report.video-card-ad-small {
             display: none !important;
         }
+        .vcd {
+            display: none !important;
+        }
         .video-page-special-card-small {
             display: none !important;
         }


### PR DESCRIPTION
在video界面，点击【隐藏 广告】发现右边的广告没有关闭，在scss加了一个类
![image](https://github.com/user-attachments/assets/3c380c17-f9ef-416a-85d4-30e4489de7c3)
