### PR TITLE
chore: 搜索页专栏过滤，支持作者黑白名单和关键词过滤，修复 prettier-plugin-tailwindcss 漏装导致的 pre-commit hook 失败 

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
         "husky": "^9.1.7",
         "lint-staged": "^17.0.4",
         "prettier": "^3.8.3",
+        "prettier-plugin-tailwindcss": "^0.8.0",
         "sass-embedded": "^1.99.0",
         "stylelint": "^17.11.0",
         "stylelint-config-standard-scss": "^17.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
+      prettier-plugin-tailwindcss:
+        specifier: ^0.8.0
+        version: 0.8.0(prettier@3.8.3)
       sass-embedded:
         specifier: ^1.99.0
         version: 1.99.0
@@ -1855,6 +1858,61 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  prettier-plugin-tailwindcss@0.8.0:
+    resolution: {integrity: sha512-V8ITGH87yuBDF6JpEZTOVlUz/saAwqb8f3HRgUj8Lh+tGCcrmorhsLpYqzygwFwK0PE2Ib6Mv3M7T/uE2tZV1g==}
+    engines: {node: '>=20.19'}
+    peerDependencies:
+      '@ianvs/prettier-plugin-sort-imports': '*'
+      '@prettier/plugin-hermes': '*'
+      '@prettier/plugin-oxc': '*'
+      '@prettier/plugin-pug': '*'
+      '@shopify/prettier-plugin-liquid': '*'
+      '@trivago/prettier-plugin-sort-imports': '*'
+      '@zackad/prettier-plugin-twig': '*'
+      prettier: ^3.0
+      prettier-plugin-astro: '*'
+      prettier-plugin-css-order: '*'
+      prettier-plugin-jsdoc: '*'
+      prettier-plugin-marko: '*'
+      prettier-plugin-multiline-arrays: '*'
+      prettier-plugin-organize-attributes: '*'
+      prettier-plugin-organize-imports: '*'
+      prettier-plugin-sort-imports: '*'
+      prettier-plugin-svelte: '*'
+    peerDependenciesMeta:
+      '@ianvs/prettier-plugin-sort-imports':
+        optional: true
+      '@prettier/plugin-hermes':
+        optional: true
+      '@prettier/plugin-oxc':
+        optional: true
+      '@prettier/plugin-pug':
+        optional: true
+      '@shopify/prettier-plugin-liquid':
+        optional: true
+      '@trivago/prettier-plugin-sort-imports':
+        optional: true
+      '@zackad/prettier-plugin-twig':
+        optional: true
+      prettier-plugin-astro:
+        optional: true
+      prettier-plugin-css-order:
+        optional: true
+      prettier-plugin-jsdoc:
+        optional: true
+      prettier-plugin-marko:
+        optional: true
+      prettier-plugin-multiline-arrays:
+        optional: true
+      prettier-plugin-organize-attributes:
+        optional: true
+      prettier-plugin-organize-imports:
+        optional: true
+      prettier-plugin-sort-imports:
+        optional: true
+      prettier-plugin-svelte:
+        optional: true
 
   prettier@3.8.3:
     resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
@@ -3903,6 +3961,10 @@ snapshots:
   powershell-utils@0.1.0: {}
 
   prelude-ls@1.2.1: {}
+
+  prettier-plugin-tailwindcss@0.8.0(prettier@3.8.3):
+    dependencies:
+      prettier: 3.8.3
 
   prettier@3.8.3: {}
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -6,6 +6,7 @@
         <DynamicFilterPanelView></DynamicFilterPanelView>
         <ContextMenuView></ContextMenuView>
         <SideBtnView></SideBtnView>
+        <ArticleFilterPanelView></ArticleFilterPanelView>
     </div>
 </template>
 <script setup lang="ts">
@@ -13,6 +14,7 @@ import CommentFilterPanelView from './views/CommentFilterPanelView.vue'
 import ContextMenuView from './views/ContextMenuView.vue'
 import DynamicFilterPanelView from './views/DynamicFilterPanelView.vue'
 import RulePanelView from './views/RulePanelView.vue'
+import ArticleFilterPanelView from './views/ArticleFilterPanelView.vue'
 import SideBtnView from './views/SideBtnView.vue'
 import VideoFilterPanelView from './views/VideoFilterPanelView.vue'
 </script>

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import App from './App.vue'
 import { loadModules } from './modules'
 import { toggleDarkMode } from './modules/rules/common/groups/theme'
 import {
+    useArticleFilterPanelStore,
     useCommentFilterPanelStore,
     useDynamicFilterPanelStore,
     useRulePanelStore,
@@ -54,6 +55,7 @@ const menu = () => {
     const videoStore = useVideoFilterPanelStore()
     const commentStore = useCommentFilterPanelStore()
     const dynamicStore = useDynamicFilterPanelStore()
+    const articleStore = useArticleFilterPanelStore()
     const sideBtnStore = useSideBtnStore()
 
     GM_registerMenuCommand('✅ 页面净化优化', () => {
@@ -68,6 +70,17 @@ const menu = () => {
             alert('[bilibili-cleaner] 本页面不支持视频过滤')
         })
     }
+
+    if (articleStore.isPageValid()) {
+        GM_registerMenuCommand('✅ 专栏过滤设置', () => {
+            articleStore.toggle()
+        })
+    } else {
+        GM_registerMenuCommand('🚫 专栏过滤设置', () => {
+            alert('[bilibili-cleaner] 本页面不支持专栏过滤')
+        })
+    }
+
     if (commentStore.isPageValid()) {
         GM_registerMenuCommand('✅ 评论过滤设置', () => {
             commentStore.toggle()
@@ -86,6 +99,7 @@ const menu = () => {
             alert('[bilibili-cleaner] 本页面不支持动态过滤')
         })
     }
+
     GM_registerMenuCommand('⚡ 夜间模式开关', () => {
         toggleDarkMode()
     })

--- a/src/modules/filters/index.ts
+++ b/src/modules/filters/index.ts
@@ -42,6 +42,7 @@ import {
 import { videoFilterSearchEntry, videoFilterSearchGroups, videoFilterSearchHandler } from './variety/video/pages/search'
 import { videoFilterSpaceEntry, videoFilterSpaceGroups, videoFilterSpaceHandler } from './variety/video/pages/space'
 import { videoFilterVideoEntry, videoFilterVideoGroups, videoFilterVideoHandler } from './variety/video/pages/video'
+import { articleFilterEntry, articleFilterGroups, articleFilterHandler } from './variety/article'
 
 /** 视频过滤器 */
 export const videoFilters: Filter[] = [
@@ -115,6 +116,16 @@ export const dynamicFilters: Filter[] = [
     },
 ]
 
+/** 专栏过滤器 */
+export const articleFilters: Filter[] = [
+    {
+        name: '搜索页 专栏过滤',
+        groups: articleFilterGroups,
+        entry: articleFilterEntry,
+        checkFn: isPageSearch,
+    },
+]
+
 /** 载入过滤器样式 */
 export const loadFilterStyle = () => {
     const style = document.createElement('style')
@@ -133,4 +144,5 @@ export const filterContextMenuHandlers = [
     videoFilterSpaceHandler,
     dynamicFilterDynamicHandler,
     commentFilterCommonHandler,
+    articleFilterHandler,
 ]

--- a/src/modules/filters/variety/article/index.ts
+++ b/src/modules/filters/variety/article/index.ts
@@ -1,0 +1,1 @@
+export { articleFilterEntry, articleFilterGroups, articleFilterHandler } from './pages/searchArticle'

--- a/src/modules/filters/variety/article/pages/searchArticle.ts
+++ b/src/modules/filters/variety/article/pages/searchArticle.ts
@@ -5,28 +5,32 @@ import { ContextMenuTargetHandler, FilterContextMenu, IMainFilter, SelectorResul
 import { logger } from '@/utils/logger'
 import { GM_getValue, GM_setValue } from '$'
 import { orderedUniq, showEle, waitForEle } from '@/utils/tool'
-import { ArticleAuthorFilter, ArticleAuthorKeywordFilter } from '../subFilters/black'
-import { ArticleAuthorKeywordWhiteFilter, ArticleAuthorWhiteFilter } from '../subFilters/white'
+import { ArticleAuthorFilter, ArticleAuthorKeywordFilter, ArticleTitleKeywordFilter } from '../subFilters/black'
+import { ArticleAuthorWhiteFilter, ArticleTitleKeywordWhiteFilter } from '../subFilters/white'
 
 const GM_KEYS = {
     black: {
-        author: {
-            statusKey: 'search-article-author-filter-status',
-            valueKey: 'search-article-author-filter-value',
+        uploader: {
+            statusKey: 'search-article-uploader-filter-status',
+            valueKey: 'global-article-uploader-filter-value',
         },
-        authorKeyword: {
-            statusKey: 'search-article-author-keyword-filter-status',
-            valueKey: 'search-article-author-keyword-filter-value',
+        uploaderKeyword: {
+            statusKey: 'search-article-uploader-keyword-filter-status',
+            valueKey: 'global-article-uploader-keyword-filter-value',
+        },
+        title: {
+            statusKey: 'search-article-title-keyword-filter-status',
+            valueKey: 'global-article-title-keyword-filter-value',
         },
     },
     white: {
-        author: {
-            statusKey: 'search-article-author-whitelist-filter-status',
-            valueKey: 'search-article-author-whitelist-filter-value',
+        uploader: {
+            statusKey: 'search-article-uploader-whitelist-filter-status',
+            valueKey: 'global-article-uploader-whitelist-filter-value',
         },
-        authorKeyword: {
-            statusKey: 'search-article-author-keyword-whitelist-filter-status',
-            valueKey: 'search-article-author-keyword-whitelist-filter-value',
+        title: {
+            statusKey: 'search-article-title-keyword-whitelist-filter-status',
+            valueKey: 'global-article-title-keyword-whitelist-filter-value',
         },
     },
 }
@@ -35,6 +39,9 @@ const selectorFns = {
     author: (card: HTMLElement): SelectorResult => {
         return card.querySelector('.atc-author .lh_xs')?.textContent?.trim()
     },
+    title: (card: HTMLElement): SelectorResult => {
+        return card.querySelector('.i_card_title a')?.getAttribute('title')?.trim()
+    },
 }
 
 class ArticleFilterSearch implements IMainFilter {
@@ -42,20 +49,20 @@ class ArticleFilterSearch implements IMainFilter {
     articleAuthorFilter = new ArticleAuthorFilter()
     articleAuthorKeywordFilter = new ArticleAuthorKeywordFilter()
     articleAuthorWhiteFilter = new ArticleAuthorWhiteFilter()
-    articleAuthorKeywordWhiteFilter = new ArticleAuthorKeywordWhiteFilter()
+    articleTitleKeywordFilter = new ArticleTitleKeywordFilter()
+    articleTitleKeywordWhiteFilter = new ArticleTitleKeywordWhiteFilter()
 
     init() {
-        const blacklist = GM_getValue<string[]>(GM_KEYS.black.author.valueKey, [])
-        const keywordBlacklist = GM_getValue<string[]>(GM_KEYS.black.authorKeyword.valueKey, [])
-        const whitelist = GM_getValue<string[]>(GM_KEYS.white.author.valueKey, [])
-        const keywordWhitelist = GM_getValue<string[]>(GM_KEYS.white.authorKeyword.valueKey, [])
-        logger.log(
-            `ArticleFilterSearch init, blacklist=${JSON.stringify(blacklist)}, keyword=${JSON.stringify(keywordBlacklist)}, whitelist=${JSON.stringify(whitelist)}, keywordWhite=${JSON.stringify(keywordWhitelist)}`,
-        )
+        const blacklist = GM_getValue<string[]>(GM_KEYS.black.uploader.valueKey, [])
+        const keywordBlacklist = GM_getValue<string[]>(GM_KEYS.black.uploaderKeyword.valueKey, [])
+        const titleKeywordBlacklist = GM_getValue<string[]>(GM_KEYS.black.title.valueKey, [])
+        const whitelist = GM_getValue<string[]>(GM_KEYS.white.uploader.valueKey, [])
+        const titleKeywordWhitelist = GM_getValue<string[]>(GM_KEYS.white.title.valueKey, [])
         this.articleAuthorFilter.setParam(blacklist)
         this.articleAuthorKeywordFilter.setParam(keywordBlacklist)
+        this.articleTitleKeywordFilter.setParam(titleKeywordBlacklist)
         this.articleAuthorWhiteFilter.setParam(whitelist)
-        this.articleAuthorKeywordWhiteFilter.setParam(keywordWhitelist)
+        this.articleTitleKeywordWhiteFilter.setParam(titleKeywordWhitelist)
     }
 
     /** 仅过滤 div.media-list 的子元素，不扫描全页面 */
@@ -73,19 +80,15 @@ class ArticleFilterSearch implements IMainFilter {
         if (
             !this.articleAuthorFilter.isEnable &&
             !this.articleAuthorKeywordFilter.isEnable &&
+            !this.articleTitleKeywordFilter.isEnable &&
             !this.articleAuthorWhiteFilter.isEnable &&
-            !this.articleAuthorKeywordWhiteFilter.isEnable
+            !this.articleTitleKeywordWhiteFilter.isEnable
         ) {
             revertAll = true
         }
         const timer = performance.now()
 
         const cards = Array.from(mediaList.children) as HTMLElement[]
-        const allAuthors = cards.map((c) => selectorFns.author(c)).filter(Boolean)
-        logger.log(`ArticleFilterSearch authors on page: [${allAuthors.join(', ')}]`)
-        logger.log(
-            `ArticleFilterSearch checkFilter, cards=${cards.length}, revertAll=${revertAll}, black=${this.articleAuthorFilter.isEnable}, keyword=${this.articleAuthorKeywordFilter.isEnable}, white=${this.articleAuthorWhiteFilter.isEnable}`,
-        )
         if (!cards.length) {
             return
         }
@@ -96,7 +99,13 @@ class ArticleFilterSearch implements IMainFilter {
 
         if (config.isDebugMode) {
             cards.forEach((c) => {
-                logger.debug(`ArticleFilterSearch author: ${selectorFns.author(c)}`)
+                logger.debug(
+                    [
+                        `ArticleFilterSearch`,
+                        `author: ${selectorFns.author(c)}`,
+                        `title: ${selectorFns.title(c)}`,
+                    ].join('\n'),
+                )
             })
         }
 
@@ -104,11 +113,13 @@ class ArticleFilterSearch implements IMainFilter {
         this.articleAuthorFilter.isEnable && blackPairs.push([this.articleAuthorFilter, selectorFns.author])
         this.articleAuthorKeywordFilter.isEnable &&
             blackPairs.push([this.articleAuthorKeywordFilter, selectorFns.author])
+        this.articleTitleKeywordFilter.isEnable &&
+            blackPairs.push([this.articleTitleKeywordFilter, selectorFns.title])
 
         const whitePairs: SubFilterPair[] = []
         this.articleAuthorWhiteFilter.isEnable && whitePairs.push([this.articleAuthorWhiteFilter, selectorFns.author])
-        this.articleAuthorKeywordWhiteFilter.isEnable &&
-            whitePairs.push([this.articleAuthorKeywordWhiteFilter, selectorFns.author])
+        this.articleTitleKeywordWhiteFilter.isEnable &&
+            whitePairs.push([this.articleTitleKeywordWhiteFilter, selectorFns.title])
 
         const blackCnt = await coreCheck(cards, true, 'sign', blackPairs, whitePairs)
         const time = (performance.now() - timer).toFixed(1)
@@ -153,12 +164,13 @@ export const articleFilterEntry = async () => {
 
 export const articleFilterGroups: Group[] = [
     {
-        name: '作者过滤',
+        name: 'UP主过滤',
         items: [
             {
                 type: 'switch',
-                id: GM_KEYS.black.author.statusKey,
-                name: '启用 作者过滤',
+                id: GM_KEYS.black.uploader.statusKey,
+                name: '启用 UP主过滤 (右键单击UP主)',
+                defaultEnable: true,
                 noStyle: true,
                 enableFn: () => {
                     mainFilter.articleAuthorFilter.enable()
@@ -171,25 +183,20 @@ export const articleFilterGroups: Group[] = [
             },
             {
                 type: 'editor',
-                id: GM_KEYS.black.author.valueKey,
+                id: GM_KEYS.black.uploader.valueKey,
                 name: '编辑 UP主黑名单',
-                description: ['右键屏蔽的作者会出现在首行'],
+                description: ['右键屏蔽的UP主会出现在首行'],
                 editorTitle: 'UP主 黑名单',
                 editorDescription: ['每行一个UP主昵称，保存时自动去重'],
                 saveFn: async () => {
-                    mainFilter.articleAuthorFilter.setParam(GM_getValue(GM_KEYS.black.author.valueKey, []))
+                    mainFilter.articleAuthorFilter.setParam(GM_getValue(GM_KEYS.black.uploader.valueKey, []))
                     mainFilter.checkFull()
                 },
             },
-        ],
-    },
-    {
-        name: '作者昵称关键词过滤',
-        items: [
             {
                 type: 'switch',
-                id: GM_KEYS.black.authorKeyword.statusKey,
-                name: '启用 作者昵称关键词过滤',
+                id: GM_KEYS.black.uploaderKeyword.statusKey,
+                name: '启用 UP主昵称关键词过滤',
                 noStyle: true,
                 enableFn: () => {
                     mainFilter.articleAuthorKeywordFilter.enable()
@@ -202,9 +209,9 @@ export const articleFilterGroups: Group[] = [
             },
             {
                 type: 'editor',
-                id: GM_KEYS.black.authorKeyword.valueKey,
-                name: '编辑 作者昵称关键词黑名单',
-                editorTitle: '作者昵称关键词 黑名单',
+                id: GM_KEYS.black.uploaderKeyword.valueKey,
+                name: '编辑 UP主昵称关键词黑名单',
+                editorTitle: 'UP主昵称关键词 黑名单',
                 editorDescription: [
                     '每行一个关键词或正则，不区分大小写、全半角',
                     '请勿使用过于激进的关键词或正则',
@@ -212,8 +219,42 @@ export const articleFilterGroups: Group[] = [
                 ],
                 saveFn: async () => {
                     mainFilter.articleAuthorKeywordFilter.setParam(
-                        GM_getValue(GM_KEYS.black.authorKeyword.valueKey, []),
+                        GM_getValue(GM_KEYS.black.uploaderKeyword.valueKey, []),
                     )
+                    mainFilter.checkFull()
+                },
+            },
+        ],
+    },
+    {
+        name: '标题关键词过滤',
+        items: [
+            {
+                type: 'switch',
+                id: GM_KEYS.black.title.statusKey,
+                name: '启用 标题关键词过滤',
+                noStyle: true,
+                enableFn: () => {
+                    mainFilter.articleTitleKeywordFilter.enable()
+                    mainFilter.checkFull()
+                },
+                disableFn: () => {
+                    mainFilter.articleTitleKeywordFilter.disable()
+                    mainFilter.checkFull()
+                },
+            },
+            {
+                type: 'editor',
+                id: GM_KEYS.black.title.valueKey,
+                name: '编辑 标题关键词黑名单',
+                editorTitle: '标题关键词 黑名单',
+                editorDescription: [
+                    '每行一个关键词或正则，不区分大小写、全半角',
+                    '请勿使用过于激进的关键词或正则',
+                    '正则默认 ius 模式，无需 flag，语法：/abc|\\d+/',
+                ],
+                saveFn: async () => {
+                    mainFilter.articleTitleKeywordFilter.setParam(GM_getValue(GM_KEYS.black.title.valueKey, []))
                     mainFilter.checkFull()
                 },
             },
@@ -224,8 +265,9 @@ export const articleFilterGroups: Group[] = [
         items: [
             {
                 type: 'switch',
-                id: GM_KEYS.white.author.statusKey,
-                name: '启用 作者白名单',
+                id: GM_KEYS.white.uploader.statusKey,
+                name: '启用 UP主白名单 (右键单击UP主)',
+                defaultEnable: true,
                 noStyle: true,
                 enableFn: () => {
                     mainFilter.articleAuthorWhiteFilter.enable()
@@ -238,39 +280,40 @@ export const articleFilterGroups: Group[] = [
             },
             {
                 type: 'editor',
-                id: GM_KEYS.white.author.valueKey,
+                id: GM_KEYS.white.uploader.valueKey,
                 name: '编辑 UP主白名单',
                 editorTitle: 'UP主 白名单',
                 editorDescription: ['每行一个UP主昵称，保存时自动去重'],
                 saveFn: async () => {
-                    mainFilter.articleAuthorWhiteFilter.setParam(GM_getValue(GM_KEYS.white.author.valueKey, []))
+                    mainFilter.articleAuthorWhiteFilter.setParam(GM_getValue(GM_KEYS.white.uploader.valueKey, []))
                     mainFilter.checkFull()
                 },
             },
             {
                 type: 'switch',
-                id: GM_KEYS.white.authorKeyword.statusKey,
-                name: '启用 作者昵称关键词白名单',
+                id: GM_KEYS.white.title.statusKey,
+                name: '启用 标题关键词白名单',
                 noStyle: true,
                 enableFn: () => {
-                    mainFilter.articleAuthorKeywordWhiteFilter.enable()
+                    mainFilter.articleTitleKeywordWhiteFilter.enable()
                     mainFilter.checkFull()
                 },
                 disableFn: () => {
-                    mainFilter.articleAuthorKeywordWhiteFilter.disable()
+                    mainFilter.articleTitleKeywordWhiteFilter.disable()
                     mainFilter.checkFull()
                 },
             },
             {
                 type: 'editor',
-                id: GM_KEYS.white.authorKeyword.valueKey,
-                name: '编辑 作者昵称关键词白名单',
-                editorTitle: '作者昵称关键词 白名单',
-                editorDescription: ['每行一个关键词或正则，不区分大小写、全半角'],
+                id: GM_KEYS.white.title.valueKey,
+                name: '编辑 标题关键词白名单',
+                editorTitle: '标题关键词 白名单',
+                editorDescription: [
+                    '每行一个关键词或正则，不区分大小写、全半角',
+                    '正则默认 ius 模式，无需 flag，语法：/abc|\\d+/',
+                ],
                 saveFn: async () => {
-                    mainFilter.articleAuthorKeywordWhiteFilter.setParam(
-                        GM_getValue(GM_KEYS.white.authorKeyword.valueKey, []),
-                    )
+                    mainFilter.articleTitleKeywordWhiteFilter.setParam(GM_getValue(GM_KEYS.white.title.valueKey, []))
                     mainFilter.checkFull()
                 },
             },
@@ -287,39 +330,48 @@ export const articleFilterHandler: ContextMenuTargetHandler = (target: HTMLEleme
     const authorEl = target.closest('.atc-author')
     if (authorEl) {
         const author = authorEl.querySelector('.lh_xs')?.textContent?.trim()
+        const url = authorEl.querySelector<HTMLAnchorElement>('a')?.href?.trim()
+        const spaceUrl = url?.match(/space\.bilibili\.com\/\d+/)?.[0]
+
         if (author) {
             if (mainFilter.articleAuthorFilter.isEnable) {
                 menus.push({
-                    name: `屏蔽作者：${author}`,
+                    name: `屏蔽UP主：${author}`,
                     fn: async () => {
                         try {
                             mainFilter.articleAuthorFilter.addParam(author)
                             mainFilter.checkFull()
-                            const arr: string[] = GM_getValue(GM_KEYS.black.author.valueKey, [])
+                            const arr: string[] = GM_getValue(GM_KEYS.black.uploader.valueKey, [])
                             arr.unshift(author)
-                            GM_setValue(GM_KEYS.black.author.valueKey, orderedUniq(arr))
+                            GM_setValue(GM_KEYS.black.uploader.valueKey, orderedUniq(arr))
                         } catch (err) {
-                            logger.error(`articleFilterHandler add author ${author} failed`, err)
+                            logger.error(`articleFilterHandler add uploader ${author} failed`, err)
                         }
                     },
                 })
             }
             if (mainFilter.articleAuthorWhiteFilter.isEnable) {
                 menus.push({
-                    name: `将作者加入白名单`,
+                    name: `将UP主加入白名单`,
                     fn: async () => {
                         try {
                             mainFilter.articleAuthorWhiteFilter.addParam(author)
                             mainFilter.checkFull()
-                            const arr: string[] = GM_getValue(GM_KEYS.white.author.valueKey, [])
+                            const arr: string[] = GM_getValue(GM_KEYS.white.uploader.valueKey, [])
                             arr.unshift(author)
-                            GM_setValue(GM_KEYS.white.author.valueKey, orderedUniq(arr))
+                            GM_setValue(GM_KEYS.white.uploader.valueKey, orderedUniq(arr))
                         } catch (err) {
-                            logger.error(`articleFilterHandler add white author ${author} failed`, err)
+                            logger.error(`articleFilterHandler add white uploader ${author} failed`, err)
                         }
                     },
                 })
             }
+        }
+        if (spaceUrl && (mainFilter.articleAuthorFilter.isEnable || mainFilter.articleAuthorWhiteFilter.isEnable)) {
+            menus.push({
+                name: `复制主页链接`,
+                fn: () => navigator.clipboard.writeText(`https://${spaceUrl}`),
+            })
         }
     }
 

--- a/src/modules/filters/variety/article/pages/searchArticle.ts
+++ b/src/modules/filters/variety/article/pages/searchArticle.ts
@@ -10,13 +10,13 @@ import { ArticleAuthorWhiteFilter, ArticleTitleKeywordWhiteFilter } from '../sub
 
 const GM_KEYS = {
     black: {
-        uploader: {
-            statusKey: 'search-article-uploader-filter-status',
-            valueKey: 'global-article-uploader-filter-value',
+        author: {
+            statusKey: 'search-article-author-filter-status',
+            valueKey: 'global-article-author-filter-value',
         },
-        uploaderKeyword: {
-            statusKey: 'search-article-uploader-keyword-filter-status',
-            valueKey: 'global-article-uploader-keyword-filter-value',
+        authorKeyword: {
+            statusKey: 'search-article-author-keyword-filter-status',
+            valueKey: 'global-article-author-keyword-filter-value',
         },
         title: {
             statusKey: 'search-article-title-keyword-filter-status',
@@ -24,9 +24,9 @@ const GM_KEYS = {
         },
     },
     white: {
-        uploader: {
-            statusKey: 'search-article-uploader-whitelist-filter-status',
-            valueKey: 'global-article-uploader-whitelist-filter-value',
+        author: {
+            statusKey: 'search-article-author-whitelist-filter-status',
+            valueKey: 'global-article-author-whitelist-filter-value',
         },
         title: {
             statusKey: 'search-article-title-keyword-whitelist-filter-status',
@@ -53,10 +53,10 @@ class ArticleFilterSearch implements IMainFilter {
     articleTitleKeywordWhiteFilter = new ArticleTitleKeywordWhiteFilter()
 
     init() {
-        const blacklist = GM_getValue<string[]>(GM_KEYS.black.uploader.valueKey, [])
-        const keywordBlacklist = GM_getValue<string[]>(GM_KEYS.black.uploaderKeyword.valueKey, [])
+        const blacklist = GM_getValue<string[]>(GM_KEYS.black.author.valueKey, [])
+        const keywordBlacklist = GM_getValue<string[]>(GM_KEYS.black.authorKeyword.valueKey, [])
         const titleKeywordBlacklist = GM_getValue<string[]>(GM_KEYS.black.title.valueKey, [])
-        const whitelist = GM_getValue<string[]>(GM_KEYS.white.uploader.valueKey, [])
+        const whitelist = GM_getValue<string[]>(GM_KEYS.white.author.valueKey, [])
         const titleKeywordWhitelist = GM_getValue<string[]>(GM_KEYS.white.title.valueKey, [])
         this.articleAuthorFilter.setParam(blacklist)
         this.articleAuthorKeywordFilter.setParam(keywordBlacklist)
@@ -164,12 +164,12 @@ export const articleFilterEntry = async () => {
 
 export const articleFilterGroups: Group[] = [
     {
-        name: 'UP主过滤',
+        name: '专栏作者过滤',
         items: [
             {
                 type: 'switch',
-                id: GM_KEYS.black.uploader.statusKey,
-                name: '启用 UP主过滤 (右键单击UP主)',
+                id: GM_KEYS.black.author.statusKey,
+                name: '启用 专栏作者过滤 (右键单击专栏作者)',
                 defaultEnable: true,
                 noStyle: true,
                 enableFn: () => {
@@ -183,20 +183,20 @@ export const articleFilterGroups: Group[] = [
             },
             {
                 type: 'editor',
-                id: GM_KEYS.black.uploader.valueKey,
-                name: '编辑 UP主黑名单',
-                description: ['右键屏蔽的UP主会出现在首行'],
-                editorTitle: 'UP主 黑名单',
-                editorDescription: ['每行一个UP主昵称，保存时自动去重'],
+                id: GM_KEYS.black.author.valueKey,
+                name: '编辑 专栏作者黑名单',
+                description: ['右键屏蔽的专栏作者会出现在首行'],
+                editorTitle: '专栏作者 黑名单',
+                editorDescription: ['每行一个专栏作者昵称，保存时自动去重'],
                 saveFn: async () => {
-                    mainFilter.articleAuthorFilter.setParam(GM_getValue(GM_KEYS.black.uploader.valueKey, []))
+                    mainFilter.articleAuthorFilter.setParam(GM_getValue(GM_KEYS.black.author.valueKey, []))
                     mainFilter.checkFull()
                 },
             },
             {
                 type: 'switch',
-                id: GM_KEYS.black.uploaderKeyword.statusKey,
-                name: '启用 UP主昵称关键词过滤',
+                id: GM_KEYS.black.authorKeyword.statusKey,
+                name: '启用 专栏作者昵称关键词过滤',
                 noStyle: true,
                 enableFn: () => {
                     mainFilter.articleAuthorKeywordFilter.enable()
@@ -209,9 +209,9 @@ export const articleFilterGroups: Group[] = [
             },
             {
                 type: 'editor',
-                id: GM_KEYS.black.uploaderKeyword.valueKey,
-                name: '编辑 UP主昵称关键词黑名单',
-                editorTitle: 'UP主昵称关键词 黑名单',
+                id: GM_KEYS.black.authorKeyword.valueKey,
+                name: '编辑 专栏作者昵称关键词黑名单',
+                editorTitle: '专栏作者昵称关键词 黑名单',
                 editorDescription: [
                     '每行一个关键词或正则，不区分大小写、全半角',
                     '请勿使用过于激进的关键词或正则',
@@ -219,7 +219,7 @@ export const articleFilterGroups: Group[] = [
                 ],
                 saveFn: async () => {
                     mainFilter.articleAuthorKeywordFilter.setParam(
-                        GM_getValue(GM_KEYS.black.uploaderKeyword.valueKey, []),
+                        GM_getValue(GM_KEYS.black.authorKeyword.valueKey, []),
                     )
                     mainFilter.checkFull()
                 },
@@ -227,12 +227,12 @@ export const articleFilterGroups: Group[] = [
         ],
     },
     {
-        name: '标题关键词过滤',
+        name: '专栏标题关键词过滤',
         items: [
             {
                 type: 'switch',
                 id: GM_KEYS.black.title.statusKey,
-                name: '启用 标题关键词过滤',
+                name: '启用 专栏标题关键词过滤',
                 noStyle: true,
                 enableFn: () => {
                     mainFilter.articleTitleKeywordFilter.enable()
@@ -246,8 +246,8 @@ export const articleFilterGroups: Group[] = [
             {
                 type: 'editor',
                 id: GM_KEYS.black.title.valueKey,
-                name: '编辑 标题关键词黑名单',
-                editorTitle: '标题关键词 黑名单',
+                name: '编辑 专栏标题关键词黑名单',
+                editorTitle: '专栏标题关键词 黑名单',
                 editorDescription: [
                     '每行一个关键词或正则，不区分大小写、全半角',
                     '请勿使用过于激进的关键词或正则',
@@ -265,8 +265,8 @@ export const articleFilterGroups: Group[] = [
         items: [
             {
                 type: 'switch',
-                id: GM_KEYS.white.uploader.statusKey,
-                name: '启用 UP主白名单 (右键单击UP主)',
+                id: GM_KEYS.white.author.statusKey,
+                name: '启用 专栏作者白名单 (右键单击专栏作者)',
                 defaultEnable: true,
                 noStyle: true,
                 enableFn: () => {
@@ -280,19 +280,19 @@ export const articleFilterGroups: Group[] = [
             },
             {
                 type: 'editor',
-                id: GM_KEYS.white.uploader.valueKey,
-                name: '编辑 UP主白名单',
-                editorTitle: 'UP主 白名单',
-                editorDescription: ['每行一个UP主昵称，保存时自动去重'],
+                id: GM_KEYS.white.author.valueKey,
+                name: '编辑 专栏作者白名单',
+                editorTitle: '专栏作者 白名单',
+                editorDescription: ['每行一个专栏作者昵称，保存时自动去重'],
                 saveFn: async () => {
-                    mainFilter.articleAuthorWhiteFilter.setParam(GM_getValue(GM_KEYS.white.uploader.valueKey, []))
+                    mainFilter.articleAuthorWhiteFilter.setParam(GM_getValue(GM_KEYS.white.author.valueKey, []))
                     mainFilter.checkFull()
                 },
             },
             {
                 type: 'switch',
                 id: GM_KEYS.white.title.statusKey,
-                name: '启用 标题关键词白名单',
+                name: '启用 专栏标题关键词白名单',
                 noStyle: true,
                 enableFn: () => {
                     mainFilter.articleTitleKeywordWhiteFilter.enable()
@@ -306,8 +306,8 @@ export const articleFilterGroups: Group[] = [
             {
                 type: 'editor',
                 id: GM_KEYS.white.title.valueKey,
-                name: '编辑 标题关键词白名单',
-                editorTitle: '标题关键词 白名单',
+                name: '编辑 专栏标题关键词白名单',
+                editorTitle: '专栏标题关键词 白名单',
                 editorDescription: [
                     '每行一个关键词或正则，不区分大小写、全半角',
                     '正则默认 ius 模式，无需 flag，语法：/abc|\\d+/',
@@ -336,32 +336,32 @@ export const articleFilterHandler: ContextMenuTargetHandler = (target: HTMLEleme
         if (author) {
             if (mainFilter.articleAuthorFilter.isEnable) {
                 menus.push({
-                    name: `屏蔽UP主：${author}`,
+                    name: `屏蔽专栏作者：${author}`,
                     fn: async () => {
                         try {
                             mainFilter.articleAuthorFilter.addParam(author)
                             mainFilter.checkFull()
-                            const arr: string[] = GM_getValue(GM_KEYS.black.uploader.valueKey, [])
+                            const arr: string[] = GM_getValue(GM_KEYS.black.author.valueKey, [])
                             arr.unshift(author)
-                            GM_setValue(GM_KEYS.black.uploader.valueKey, orderedUniq(arr))
+                            GM_setValue(GM_KEYS.black.author.valueKey, orderedUniq(arr))
                         } catch (err) {
-                            logger.error(`articleFilterHandler add uploader ${author} failed`, err)
+                            logger.error(`articleFilterHandler add author ${author} failed`, err)
                         }
                     },
                 })
             }
             if (mainFilter.articleAuthorWhiteFilter.isEnable) {
                 menus.push({
-                    name: `将UP主加入白名单`,
+                    name: `将专栏作者加入白名单`,
                     fn: async () => {
                         try {
                             mainFilter.articleAuthorWhiteFilter.addParam(author)
                             mainFilter.checkFull()
-                            const arr: string[] = GM_getValue(GM_KEYS.white.uploader.valueKey, [])
+                            const arr: string[] = GM_getValue(GM_KEYS.white.author.valueKey, [])
                             arr.unshift(author)
-                            GM_setValue(GM_KEYS.white.uploader.valueKey, orderedUniq(arr))
+                            GM_setValue(GM_KEYS.white.author.valueKey, orderedUniq(arr))
                         } catch (err) {
-                            logger.error(`articleFilterHandler add white uploader ${author} failed`, err)
+                            logger.error(`articleFilterHandler add white author ${author} failed`, err)
                         }
                     },
                 })

--- a/src/modules/filters/variety/article/pages/searchArticle.ts
+++ b/src/modules/filters/variety/article/pages/searchArticle.ts
@@ -4,7 +4,7 @@ import { Group } from '@/types/collection'
 import { ContextMenuTargetHandler, FilterContextMenu, IMainFilter, SelectorResult, SubFilterPair } from '@/types/filter'
 import { logger } from '@/utils/logger'
 import { GM_getValue, GM_setValue } from '$'
-import { orderedUniq, showEle } from '@/utils/tool'
+import { orderedUniq, showEle, waitForEle } from '@/utils/tool'
 import { ArticleAuthorFilter, ArticleAuthorKeywordFilter } from '../subFilters/black'
 import { ArticleAuthorKeywordWhiteFilter, ArticleAuthorWhiteFilter } from '../subFilters/white'
 
@@ -31,8 +31,6 @@ const GM_KEYS = {
     },
 }
 
-const isArticleUrl = () => location.href.includes('search.bilibili.com/article')
-
 const selectorFns = {
     author: (card: HTMLElement): SelectorResult => {
         return card.querySelector('.atc-author .lh_xs')?.textContent?.trim()
@@ -41,9 +39,6 @@ const selectorFns = {
 
 class ArticleFilterSearch implements IMainFilter {
     target: HTMLElement | undefined
-    private mediaObserver: MutationObserver | null = null
-    private watchTimer: ReturnType<typeof setTimeout> | null = null
-
     articleAuthorFilter = new ArticleAuthorFilter()
     articleAuthorKeywordFilter = new ArticleAuthorKeywordFilter()
     articleAuthorWhiteFilter = new ArticleAuthorWhiteFilter()
@@ -63,54 +58,14 @@ class ArticleFilterSearch implements IMainFilter {
         this.articleAuthorKeywordWhiteFilter.setParam(keywordWhitelist)
     }
 
-    /** 查找 div.media-list 并建立观察 */
-    private setupMediaList() {
-        if (!isArticleUrl()) {
-            this.teardown()
-            return
-        }
-        const mediaList = document.querySelector<HTMLElement>('div.media-list')
-        if (!mediaList) {
-            // 还没渲染，轮询等待
-            if (!this.watchTimer) {
-                this.watchTimer = setTimeout(() => {
-                    this.watchTimer = null
-                    this.setupMediaList()
-                }, 500)
-            }
-            return
-        }
-
-        if (this.target === mediaList) {
-            this.checkFilter()
-            return
-        }
-
-        logger.log('ArticleFilterSearch div.media-list found')
-        this.mediaObserver?.disconnect()
-        this.target = mediaList
-        this.mediaObserver = new MutationObserver(() => {
-            this.checkFilter()
-        })
-        this.mediaObserver.observe(this.target, { childList: true, subtree: true })
-        this.checkFilter()
-    }
-
-    /** 取消观察和轮询 */
-    private teardown() {
-        if (this.watchTimer) {
-            clearTimeout(this.watchTimer)
-            this.watchTimer = null
-        }
-        this.mediaObserver?.disconnect()
-        this.mediaObserver = null
-        this.target = undefined
-        document.querySelectorAll<HTMLElement>(`[${config.filterHideSign}]`).forEach((c) => showEle(c, 'sign'))
-    }
-
     /** 仅过滤 div.media-list 的子元素，不扫描全页面 */
     private async checkFilter() {
         if (!this.target) {
+            return
+        }
+
+        const mediaList = this.target.querySelector<HTMLElement>('div.media-list')
+        if (!mediaList) {
             return
         }
 
@@ -125,7 +80,7 @@ class ArticleFilterSearch implements IMainFilter {
         }
         const timer = performance.now()
 
-        const cards = Array.from(this.target.children) as HTMLElement[]
+        const cards = Array.from(mediaList.children) as HTMLElement[]
         const allAuthors = cards.map((c) => selectorFns.author(c)).filter(Boolean)
         logger.log(`ArticleFilterSearch authors on page: [${allAuthors.join(', ')}]`)
         logger.log(
@@ -160,43 +115,32 @@ class ArticleFilterSearch implements IMainFilter {
         logger.debug(`ArticleFilterSearch hide ${blackCnt} in ${cards.length} cards, time=${time}`)
     }
 
+    observe() {
+        logger.log('ArticleFilterSearch observe')
+        waitForEle(document, 'div.search-content', (node: HTMLElement): boolean => {
+            return node.className.includes('search-content')
+        }).then((ele) => {
+            if (!ele) {
+                return
+            }
+
+            logger.log('ArticleFilterSearch div.search-content found')
+            this.target = ele
+            this.checkFilter()
+
+            new MutationObserver(() => {
+                this.checkFilter()
+            }).observe(this.target, { childList: true, subtree: true })
+        })
+    }
+
     /** 兼容 IMainFilter 接口 */
     check(_mode?: 'full' | 'incr') {
-        this.setupMediaList()
+        this.checkFilter()
     }
 
     checkFull() {
-        this.setupMediaList()
-    }
-
-    /** SPA URL 变化时延迟重查 DOM（需等 DOM 更新完再找容器） */
-    private onUrlChange() {
-        this.target = undefined
-        this.mediaObserver?.disconnect()
-        this.mediaObserver = null
-        if (this.watchTimer) {
-            clearTimeout(this.watchTimer)
-            this.watchTimer = null
-        }
-        setTimeout(() => this.setupMediaList(), 0)
-    }
-
-    observe() {
-        logger.log('ArticleFilterSearch observe')
-        this.setupMediaList()
-
-        // 拦截 pushState / replaceState 感知 SPA URL 变化
-        const origPushState = history.pushState.bind(history)
-        history.pushState = (...args) => {
-            origPushState(...args)
-            this.onUrlChange()
-        }
-        const origReplaceState = history.replaceState.bind(history)
-        history.replaceState = (...args) => {
-            origReplaceState(...args)
-            this.onUrlChange()
-        }
-        window.addEventListener('popstate', () => this.onUrlChange())
+        this.checkFilter()
     }
 }
 

--- a/src/modules/filters/variety/article/pages/searchArticle.ts
+++ b/src/modules/filters/variety/article/pages/searchArticle.ts
@@ -1,0 +1,383 @@
+import { coreCheck } from '@/modules/filters/core/core'
+import config from '@/config'
+import { Group } from '@/types/collection'
+import { ContextMenuTargetHandler, FilterContextMenu, IMainFilter, SelectorResult, SubFilterPair } from '@/types/filter'
+import { logger } from '@/utils/logger'
+import { GM_getValue, GM_setValue } from '$'
+import { orderedUniq, showEle } from '@/utils/tool'
+import { ArticleAuthorFilter, ArticleAuthorKeywordFilter } from '../subFilters/black'
+import { ArticleAuthorKeywordWhiteFilter, ArticleAuthorWhiteFilter } from '../subFilters/white'
+
+const GM_KEYS = {
+    black: {
+        author: {
+            statusKey: 'search-article-author-filter-status',
+            valueKey: 'search-article-author-filter-value',
+        },
+        authorKeyword: {
+            statusKey: 'search-article-author-keyword-filter-status',
+            valueKey: 'search-article-author-keyword-filter-value',
+        },
+    },
+    white: {
+        author: {
+            statusKey: 'search-article-author-whitelist-filter-status',
+            valueKey: 'search-article-author-whitelist-filter-value',
+        },
+        authorKeyword: {
+            statusKey: 'search-article-author-keyword-whitelist-filter-status',
+            valueKey: 'search-article-author-keyword-whitelist-filter-value',
+        },
+    },
+}
+
+const isArticleUrl = () => location.href.includes('search.bilibili.com/article')
+
+const selectorFns = {
+    author: (card: HTMLElement): SelectorResult => {
+        return card.querySelector('.atc-author .lh_xs')?.textContent?.trim()
+    },
+}
+
+class ArticleFilterSearch implements IMainFilter {
+    target: HTMLElement | undefined
+    private mediaObserver: MutationObserver | null = null
+    private watchTimer: ReturnType<typeof setTimeout> | null = null
+
+    articleAuthorFilter = new ArticleAuthorFilter()
+    articleAuthorKeywordFilter = new ArticleAuthorKeywordFilter()
+    articleAuthorWhiteFilter = new ArticleAuthorWhiteFilter()
+    articleAuthorKeywordWhiteFilter = new ArticleAuthorKeywordWhiteFilter()
+
+    init() {
+        const blacklist = GM_getValue<string[]>(GM_KEYS.black.author.valueKey, [])
+        const keywordBlacklist = GM_getValue<string[]>(GM_KEYS.black.authorKeyword.valueKey, [])
+        const whitelist = GM_getValue<string[]>(GM_KEYS.white.author.valueKey, [])
+        const keywordWhitelist = GM_getValue<string[]>(GM_KEYS.white.authorKeyword.valueKey, [])
+        logger.log(
+            `ArticleFilterSearch init, blacklist=${JSON.stringify(blacklist)}, keyword=${JSON.stringify(keywordBlacklist)}, whitelist=${JSON.stringify(whitelist)}, keywordWhite=${JSON.stringify(keywordWhitelist)}`,
+        )
+        this.articleAuthorFilter.setParam(blacklist)
+        this.articleAuthorKeywordFilter.setParam(keywordBlacklist)
+        this.articleAuthorWhiteFilter.setParam(whitelist)
+        this.articleAuthorKeywordWhiteFilter.setParam(keywordWhitelist)
+    }
+
+    /** 查找 div.media-list 并建立观察 */
+    private setupMediaList() {
+        if (!isArticleUrl()) {
+            this.teardown()
+            return
+        }
+        const mediaList = document.querySelector<HTMLElement>('div.media-list')
+        if (!mediaList) {
+            // 还没渲染，轮询等待
+            if (!this.watchTimer) {
+                this.watchTimer = setTimeout(() => {
+                    this.watchTimer = null
+                    this.setupMediaList()
+                }, 500)
+            }
+            return
+        }
+
+        if (this.target === mediaList) {
+            this.checkFilter()
+            return
+        }
+
+        logger.log('ArticleFilterSearch div.media-list found')
+        this.mediaObserver?.disconnect()
+        this.target = mediaList
+        this.mediaObserver = new MutationObserver(() => {
+            this.checkFilter()
+        })
+        this.mediaObserver.observe(this.target, { childList: true, subtree: true })
+        this.checkFilter()
+    }
+
+    /** 取消观察和轮询 */
+    private teardown() {
+        if (this.watchTimer) {
+            clearTimeout(this.watchTimer)
+            this.watchTimer = null
+        }
+        this.mediaObserver?.disconnect()
+        this.mediaObserver = null
+        this.target = undefined
+        document.querySelectorAll<HTMLElement>(`[${config.filterHideSign}]`).forEach((c) => showEle(c, 'sign'))
+    }
+
+    /** 仅过滤 div.media-list 的子元素，不扫描全页面 */
+    private async checkFilter() {
+        if (!this.target) {
+            return
+        }
+
+        let revertAll = false
+        if (
+            !this.articleAuthorFilter.isEnable &&
+            !this.articleAuthorKeywordFilter.isEnable &&
+            !this.articleAuthorWhiteFilter.isEnable &&
+            !this.articleAuthorKeywordWhiteFilter.isEnable
+        ) {
+            revertAll = true
+        }
+        const timer = performance.now()
+
+        const cards = Array.from(this.target.children) as HTMLElement[]
+        const allAuthors = cards.map((c) => selectorFns.author(c)).filter(Boolean)
+        logger.log(`ArticleFilterSearch authors on page: [${allAuthors.join(', ')}]`)
+        logger.log(
+            `ArticleFilterSearch checkFilter, cards=${cards.length}, revertAll=${revertAll}, black=${this.articleAuthorFilter.isEnable}, keyword=${this.articleAuthorKeywordFilter.isEnable}, white=${this.articleAuthorWhiteFilter.isEnable}`,
+        )
+        if (!cards.length) {
+            return
+        }
+        if (revertAll) {
+            cards.forEach((c) => showEle(c, 'sign'))
+            return
+        }
+
+        if (config.isDebugMode) {
+            cards.forEach((c) => {
+                logger.debug(`ArticleFilterSearch author: ${selectorFns.author(c)}`)
+            })
+        }
+
+        const blackPairs: SubFilterPair[] = []
+        this.articleAuthorFilter.isEnable && blackPairs.push([this.articleAuthorFilter, selectorFns.author])
+        this.articleAuthorKeywordFilter.isEnable &&
+            blackPairs.push([this.articleAuthorKeywordFilter, selectorFns.author])
+
+        const whitePairs: SubFilterPair[] = []
+        this.articleAuthorWhiteFilter.isEnable && whitePairs.push([this.articleAuthorWhiteFilter, selectorFns.author])
+        this.articleAuthorKeywordWhiteFilter.isEnable &&
+            whitePairs.push([this.articleAuthorKeywordWhiteFilter, selectorFns.author])
+
+        const blackCnt = await coreCheck(cards, true, 'sign', blackPairs, whitePairs)
+        const time = (performance.now() - timer).toFixed(1)
+        logger.debug(`ArticleFilterSearch hide ${blackCnt} in ${cards.length} cards, time=${time}`)
+    }
+
+    /** 兼容 IMainFilter 接口 */
+    check(_mode?: 'full' | 'incr') {
+        this.setupMediaList()
+    }
+
+    checkFull() {
+        this.setupMediaList()
+    }
+
+    /** SPA URL 变化时延迟重查 DOM（需等 DOM 更新完再找容器） */
+    private onUrlChange() {
+        this.target = undefined
+        this.mediaObserver?.disconnect()
+        this.mediaObserver = null
+        if (this.watchTimer) {
+            clearTimeout(this.watchTimer)
+            this.watchTimer = null
+        }
+        setTimeout(() => this.setupMediaList(), 0)
+    }
+
+    observe() {
+        logger.log('ArticleFilterSearch observe')
+        this.setupMediaList()
+
+        // 拦截 pushState / replaceState 感知 SPA URL 变化
+        const origPushState = history.pushState.bind(history)
+        history.pushState = (...args) => {
+            origPushState(...args)
+            this.onUrlChange()
+        }
+        const origReplaceState = history.replaceState.bind(history)
+        history.replaceState = (...args) => {
+            origReplaceState(...args)
+            this.onUrlChange()
+        }
+        window.addEventListener('popstate', () => this.onUrlChange())
+    }
+}
+
+const mainFilter = new ArticleFilterSearch()
+
+export const articleFilterEntry = async () => {
+    mainFilter.init()
+    mainFilter.observe()
+}
+
+export const articleFilterGroups: Group[] = [
+    {
+        name: '作者过滤',
+        items: [
+            {
+                type: 'switch',
+                id: GM_KEYS.black.author.statusKey,
+                name: '启用 作者过滤',
+                noStyle: true,
+                enableFn: () => {
+                    mainFilter.articleAuthorFilter.enable()
+                    mainFilter.checkFull()
+                },
+                disableFn: () => {
+                    mainFilter.articleAuthorFilter.disable()
+                    mainFilter.checkFull()
+                },
+            },
+            {
+                type: 'editor',
+                id: GM_KEYS.black.author.valueKey,
+                name: '编辑 UP主黑名单',
+                description: ['右键屏蔽的作者会出现在首行'],
+                editorTitle: 'UP主 黑名单',
+                editorDescription: ['每行一个UP主昵称，保存时自动去重'],
+                saveFn: async () => {
+                    mainFilter.articleAuthorFilter.setParam(GM_getValue(GM_KEYS.black.author.valueKey, []))
+                    mainFilter.checkFull()
+                },
+            },
+        ],
+    },
+    {
+        name: '作者昵称关键词过滤',
+        items: [
+            {
+                type: 'switch',
+                id: GM_KEYS.black.authorKeyword.statusKey,
+                name: '启用 作者昵称关键词过滤',
+                noStyle: true,
+                enableFn: () => {
+                    mainFilter.articleAuthorKeywordFilter.enable()
+                    mainFilter.checkFull()
+                },
+                disableFn: () => {
+                    mainFilter.articleAuthorKeywordFilter.disable()
+                    mainFilter.checkFull()
+                },
+            },
+            {
+                type: 'editor',
+                id: GM_KEYS.black.authorKeyword.valueKey,
+                name: '编辑 作者昵称关键词黑名单',
+                editorTitle: '作者昵称关键词 黑名单',
+                editorDescription: [
+                    '每行一个关键词或正则，不区分大小写、全半角',
+                    '请勿使用过于激进的关键词或正则',
+                    '正则默认 ius 模式，无需 flag，语法：/abc|\\d+/',
+                ],
+                saveFn: async () => {
+                    mainFilter.articleAuthorKeywordFilter.setParam(
+                        GM_getValue(GM_KEYS.black.authorKeyword.valueKey, []),
+                    )
+                    mainFilter.checkFull()
+                },
+            },
+        ],
+    },
+    {
+        name: '白名单 免过滤',
+        items: [
+            {
+                type: 'switch',
+                id: GM_KEYS.white.author.statusKey,
+                name: '启用 作者白名单',
+                noStyle: true,
+                enableFn: () => {
+                    mainFilter.articleAuthorWhiteFilter.enable()
+                    mainFilter.checkFull()
+                },
+                disableFn: () => {
+                    mainFilter.articleAuthorWhiteFilter.disable()
+                    mainFilter.checkFull()
+                },
+            },
+            {
+                type: 'editor',
+                id: GM_KEYS.white.author.valueKey,
+                name: '编辑 UP主白名单',
+                editorTitle: 'UP主 白名单',
+                editorDescription: ['每行一个UP主昵称，保存时自动去重'],
+                saveFn: async () => {
+                    mainFilter.articleAuthorWhiteFilter.setParam(GM_getValue(GM_KEYS.white.author.valueKey, []))
+                    mainFilter.checkFull()
+                },
+            },
+            {
+                type: 'switch',
+                id: GM_KEYS.white.authorKeyword.statusKey,
+                name: '启用 作者昵称关键词白名单',
+                noStyle: true,
+                enableFn: () => {
+                    mainFilter.articleAuthorKeywordWhiteFilter.enable()
+                    mainFilter.checkFull()
+                },
+                disableFn: () => {
+                    mainFilter.articleAuthorKeywordWhiteFilter.disable()
+                    mainFilter.checkFull()
+                },
+            },
+            {
+                type: 'editor',
+                id: GM_KEYS.white.authorKeyword.valueKey,
+                name: '编辑 作者昵称关键词白名单',
+                editorTitle: '作者昵称关键词 白名单',
+                editorDescription: ['每行一个关键词或正则，不区分大小写、全半角'],
+                saveFn: async () => {
+                    mainFilter.articleAuthorKeywordWhiteFilter.setParam(
+                        GM_getValue(GM_KEYS.white.authorKeyword.valueKey, []),
+                    )
+                    mainFilter.checkFull()
+                },
+            },
+        ],
+    },
+]
+
+export const articleFilterHandler: ContextMenuTargetHandler = (target: HTMLElement): FilterContextMenu[] => {
+    if (location.host !== 'search.bilibili.com') {
+        return []
+    }
+
+    const menus: FilterContextMenu[] = []
+    const authorEl = target.closest('.atc-author')
+    if (authorEl) {
+        const author = authorEl.querySelector('.lh_xs')?.textContent?.trim()
+        if (author) {
+            if (mainFilter.articleAuthorFilter.isEnable) {
+                menus.push({
+                    name: `屏蔽作者：${author}`,
+                    fn: async () => {
+                        try {
+                            mainFilter.articleAuthorFilter.addParam(author)
+                            mainFilter.checkFull()
+                            const arr: string[] = GM_getValue(GM_KEYS.black.author.valueKey, [])
+                            arr.unshift(author)
+                            GM_setValue(GM_KEYS.black.author.valueKey, orderedUniq(arr))
+                        } catch (err) {
+                            logger.error(`articleFilterHandler add author ${author} failed`, err)
+                        }
+                    },
+                })
+            }
+            if (mainFilter.articleAuthorWhiteFilter.isEnable) {
+                menus.push({
+                    name: `将作者加入白名单`,
+                    fn: async () => {
+                        try {
+                            mainFilter.articleAuthorWhiteFilter.addParam(author)
+                            mainFilter.checkFull()
+                            const arr: string[] = GM_getValue(GM_KEYS.white.author.valueKey, [])
+                            arr.unshift(author)
+                            GM_setValue(GM_KEYS.white.author.valueKey, orderedUniq(arr))
+                        } catch (err) {
+                            logger.error(`articleFilterHandler add white author ${author} failed`, err)
+                        }
+                    },
+                })
+            }
+        }
+    }
+
+    return menus
+}

--- a/src/modules/filters/variety/article/subFilters/black.ts
+++ b/src/modules/filters/variety/article/subFilters/black.ts
@@ -4,3 +4,5 @@ import { StringFilter } from '@/modules/filters/core/subFilters/stringFilter'
 export class ArticleAuthorFilter extends StringFilter {}
 
 export class ArticleAuthorKeywordFilter extends KeywordFilter {}
+
+export class ArticleTitleKeywordFilter extends KeywordFilter {}

--- a/src/modules/filters/variety/article/subFilters/black.ts
+++ b/src/modules/filters/variety/article/subFilters/black.ts
@@ -1,0 +1,6 @@
+import { KeywordFilter } from '@/modules/filters/core/subFilters/keywordFilter'
+import { StringFilter } from '@/modules/filters/core/subFilters/stringFilter'
+
+export class ArticleAuthorFilter extends StringFilter {}
+
+export class ArticleAuthorKeywordFilter extends KeywordFilter {}

--- a/src/modules/filters/variety/article/subFilters/white.ts
+++ b/src/modules/filters/variety/article/subFilters/white.ts
@@ -1,0 +1,6 @@
+import { KeywordFilter } from '@/modules/filters/core/subFilters/keywordFilter'
+import { StringFilter } from '@/modules/filters/core/subFilters/stringFilter'
+
+export class ArticleAuthorWhiteFilter extends StringFilter {}
+
+export class ArticleAuthorKeywordWhiteFilter extends KeywordFilter {}

--- a/src/modules/filters/variety/article/subFilters/white.ts
+++ b/src/modules/filters/variety/article/subFilters/white.ts
@@ -3,4 +3,4 @@ import { StringFilter } from '@/modules/filters/core/subFilters/stringFilter'
 
 export class ArticleAuthorWhiteFilter extends StringFilter {}
 
-export class ArticleAuthorKeywordWhiteFilter extends KeywordFilter {}
+export class ArticleTitleKeywordWhiteFilter extends KeywordFilter {}

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -3,7 +3,7 @@ import { waitForHead } from '@/utils/init'
 import { logger } from '@/utils/logger'
 import { GM_getValue } from '$'
 import { useMagicKeys } from '@vueuse/core'
-import { commentFilters, dynamicFilters, loadFilterStyle, videoFilters } from './filters'
+import { articleFilters, commentFilters, dynamicFilters, loadFilterStyle, videoFilters } from './filters'
 import { loadRuleStyle, rules } from './rules'
 
 const loadSwitchItem = (item: ISwitchItem) => {
@@ -91,7 +91,7 @@ const loadRules = () => {
 
 /** 载入过滤器 */
 const loadFilters = () => {
-    const filters = [...videoFilters, ...commentFilters, ...dynamicFilters]
+    const filters = [...videoFilters, ...commentFilters, ...dynamicFilters, ...articleFilters]
     for (const filter of filters) {
         if (filter.checkFn()) {
             try {

--- a/src/stores/view.ts
+++ b/src/stores/view.ts
@@ -105,3 +105,18 @@ export const useSideBtnStore = defineStore('SideBtn', () => {
     }
     return { isShow, show, hide, toggle }
 })
+
+export const useArticleFilterPanelStore = defineStore('ArticleFilterPanel', () => {
+    const isShow = ref(false)
+    const show = () => {
+        isShow.value = true
+    }
+    const hide = () => {
+        isShow.value = false
+    }
+    const toggle = () => {
+        isShow.value = !isShow.value
+    }
+    const isPageValid = () => isPageSearch()
+    return { isShow, show, hide, toggle, isPageValid }
+})

--- a/src/views/ArticleFilterPanelView.vue
+++ b/src/views/ArticleFilterPanelView.vue
@@ -1,0 +1,56 @@
+<template>
+    <PanelComp
+        v-bind="{
+            title: '专栏过滤',
+            widthPercent: 28,
+            heightPercent: 85,
+            minWidth: 360,
+            minHeight: 600,
+        }"
+        v-show="store.isShow"
+        @close="store.hide"
+    >
+        <div v-for="(group, index) in currPageGroups" :key="index">
+            <DisclosureComp v-bind="{ title: group.name, isFold: group.fold }">
+                <div v-for="(item, innerIndex) in group.items" :key="innerIndex">
+                    <SwitchComp v-if="item.type === 'switch'" v-bind="item"></SwitchComp>
+                    <NumberComp v-else-if="item.type === 'number'" v-bind="item"></NumberComp>
+                    <StringComp v-else-if="item.type === 'string'" v-bind="item"></StringComp>
+                    <EditorComp v-else-if="item.type === 'editor'" v-bind="item" @edit="handleEdit"></EditorComp>
+                    <ListComp v-else-if="item.type === 'list'" v-bind="item"></ListComp>
+                </div>
+            </DisclosureComp>
+        </div>
+        <EditorDialog ref="editorDialogRef"></EditorDialog>
+    </PanelComp>
+</template>
+
+<script setup lang="ts">
+import DisclosureComp from '@/components/DisclosureComp.vue'
+import EditorDialog from '@/components/EditorDialog.vue'
+import EditorComp from '@/components/items/EditorComp.vue'
+import ListComp from '@/components/items/ListComp.vue'
+import NumberComp from '@/components/items/NumberComp.vue'
+import StringComp from '@/components/items/StringComp.vue'
+import SwitchComp from '@/components/items/SwitchComp.vue'
+import PanelComp from '@/components/PanelComp.vue'
+import { articleFilters } from '@/modules/filters'
+import { useArticleFilterPanelStore } from '@/stores/view'
+import { Group } from '@/types/collection'
+import { IEditorItem } from '@/types/item'
+import { ref } from 'vue'
+
+const store = useArticleFilterPanelStore()
+const editorDialogRef = ref<InstanceType<typeof EditorDialog> | null>(null)
+
+const handleEdit = (item: IEditorItem) => {
+    editorDialogRef.value?.openEditor(item)
+}
+
+let currPageGroups: Group[] = []
+for (const articleFilter of articleFilters) {
+    if (articleFilter.checkFn()) {
+        currPageGroups = [...currPageGroups, ...articleFilter.groups]
+    }
+}
+</script>


### PR DESCRIPTION
两个commit的内容
- 新增搜索页专栏过滤功能，支持按作者黑白名单和昵称关键词过滤
- 补装 prettier-plugin-tailwindcss，修复 https://github.com/festoney8/bilibili-cleaner/commit/e88ccd693753f38d9fbce2ddcfb8cbeba7b12dbc 升级 tailwind v4 时遗漏的依赖。
不然 pre-commit 钩子里的 lint-staged 直接报错，没法commit

其余模棱两可或者两者皆可的
- 专栏过滤器的key没有复用视频过滤的，两者的名单保持隔离
- 专栏过滤的页面几乎和视频过滤一模一样，好像没什么可以精简的地方